### PR TITLE
Add Support for loading fromMobx attributes from mixins on components.

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -69,7 +69,14 @@ function createComputedProperty(
 }
 
 function getFromStoreEntries(vm: VueClass): FromMobxEntry[] {
-  const fromStore = vm.$options.fromMobx
+  let fromStore = vm.$options.fromMobx
+  if (vm.$options.mixins) {
+    var fromStoreNew = vm.$options.mixins
+      .map(mixin => mixin.fromMobx)
+      .reduce((accum, mobx) => mobx ? Object.assign({}, accum, mobx) : accum, {})
+    fromStore = Object.assign({}, fromStore, fromStoreNew)
+  }
+
   if (!fromStore) {
     return []
   }

--- a/test/index.ts
+++ b/test/index.ts
@@ -453,3 +453,36 @@ test('normal components destroy well', () => {
 
   vm.$destroy()
 })
+
+test('fromMobx attributes pulled from mixins', () => {
+  Vue.use(Movue)
+
+  const data = observable({
+    foo: 1
+  })
+
+  const mixin = {
+    fromMobx: {
+      foo () {
+        return data.foo
+      }
+    }
+  }
+
+  const vm = new Vue({
+    mixins: [mixin],
+    computed: {
+      value () {
+        return this.foo
+      }
+    },
+    render (h) {
+      const vm: any = this
+      return h('div', `${vm.value}`)
+    }
+  }).$mount()
+
+  expect(vm.foo).toBe(1)
+
+  vm.$destroy()
+})


### PR DESCRIPTION
The current functionality of the library does not allow loading `fromMobx` attributes from a mixin on a component. See example below:

```
const data = observable({
  foo: 1
})

const mixin = {
  fromMobx: {
    foo () {
      return data.foo
    }
  }
}

const vm = new Vue({
  mixins: [mixin],
  computed: {
    value () {
      // This value will be undefined in the current version.
      return this.foo
    }
  },
  render (h) {
    const vm: any = this
    return h('div', `${vm.value}`)
  }
})
```

As it stands, right now, the value `foo` will not be defined in the top-level component. This pull request pulls `fromMobx` attributes from mixins one-level below the top-level component to allow Movue to be used in mixin abstraction.